### PR TITLE
Update FastScrollCollectionView.swift

### DIFF
--- a/FastScroll/FastScrollCollectionView.swift
+++ b/FastScroll/FastScrollCollectionView.swift
@@ -366,7 +366,9 @@ extension FastScrollCollectionView {
         
         //invalid timer
         if let handleTimer = handleTimer {
-            handleTimer.invalidate()
+            if handleTimer.isValid{
+                handleTimer.invalidate()
+            }
         }
         
         //scroll position


### PR DESCRIPTION
Hi, I encountered a BAD ACCESS exception when scrollViewDidScroll called multiple times it crashed.
The reason is we try to invalidate timer even if it already invalidated. It always crashes. It is the fix